### PR TITLE
Add load statement for tf_native_cc_binary in BUILD file

### DIFF
--- a/tensorflow/tools/android/test/jni/object_tracking/BUILD
+++ b/tensorflow/tools/android/test/jni/object_tracking/BUILD
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//tensorflow:tensorflow.bzl", "tf_native_cc_binary")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],


### PR DESCRIPTION
Added the required `load("//tensorflow:tensorflow.bzl", "tf_native_cc_binary")` statement at the top of the BUILD file.